### PR TITLE
Preemptively fixing HCP Packer learn repo

### DIFF
--- a/ubuntu-xenial.pkr.hcl
+++ b/ubuntu-xenial.pkr.hcl
@@ -53,7 +53,7 @@ build {
     description = <<EOT
 Some nice description about the image being published to HCP Packer Registry.
     EOT
-    labels = {
+    bucket_labels = {
       "foo-version" = "3.4.0",
       "foo"         = "bar",
     }


### PR DESCRIPTION
I was doing some brushing up on HCP Packer and saw the CLI warning for deprecation of 'labels'. I went ahead and replaced 'labels' with 'bucket_labels' so there's no warnings moving forward.