### PR TITLE
Replace error_revoked references with revoke_at output

### DIFF
--- a/tf-revoked-iteration/main.tf
+++ b/tf-revoked-iteration/main.tf
@@ -12,7 +12,7 @@ data "hcp_packer_image" "ubuntu_us_east_2" {
 }
 
 resource "aws_instance" "app_server" {
-  count = data.hcp_packer_image.ubuntu_us_east_2.cloud_image_id == "error_revoked" ? 0 : 1
+  count = data.hcp_packer_image.ubuntu_us_east_2.revoke_at == null ? 1 : 0
 
   ami           = data.hcp_packer_image.ubuntu_us_east_2.cloud_image_id
   instance_type = "t2.micro"

--- a/tf-revoked-iteration/outputs.tf
+++ b/tf-revoked-iteration/outputs.tf
@@ -1,3 +1,3 @@
 output "image_status" {
-  value = data.hcp_packer_image.ubuntu_us_east_2.cloud_image_id
+  value = data.hcp_packer_image.ubuntu_us_east_2.revoke_at
 }

--- a/tf-revoked-iteration/outputs.tf
+++ b/tf-revoked-iteration/outputs.tf
@@ -1,3 +1,3 @@
-output "image_status" {
+output "image_revoke_at" {
   value = data.hcp_packer_image.ubuntu_us_east_2.revoke_at
 }

--- a/tf-revoked-iteration/outputs.tf
+++ b/tf-revoked-iteration/outputs.tf
@@ -1,3 +1,3 @@
-output "image_revoke_at" {
+output "image_revocation_date" {
   value = data.hcp_packer_image.ubuntu_us_east_2.revoke_at
 }


### PR DESCRIPTION
The changes present in this PR depend on the next release of https://github.com/hashicorp/terraform-provider-hcp, so we must merge this one only after v0.33.0 is released.